### PR TITLE
More robust theming

### DIFF
--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -37,6 +37,8 @@ assistant. Include one emoji at the start of the title. Here are some examples:
 Ensure the title is a summary of the chat message, and make sure it is as
 accurate as possible, without anything made-up or inferred about the message.
 Here is the messsage: `,
+    THEME_ACCENT_COLOR: process.env.THEME_ACCENT_COLOR ?? "gray",
+    THEME_APPEARANCE: process.env.THEME_APPEARANCE ?? "dark",
   },
 };
 

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -39,6 +39,8 @@ accurate as possible, without anything made-up or inferred about the message.
 Here is the messsage: `,
     THEME_ACCENT_COLOR: process.env.THEME_ACCENT_COLOR ?? "gray",
     THEME_APPEARANCE: process.env.THEME_APPEARANCE ?? "dark",
+    DISABLE_USER_SET_THEME_ACCENT_COLOR:
+      !!process.env.DISABLE_USER_SET_THEME_ACCENT_COLOR,
   },
 };
 

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "@radix-ui/themes": "^3.2.1",
         "@tailwindcss/vite": "^4.1.7",
         "@tanstack/react-query": "^5.76.1",
+        "@uidotdev/usehooks": "^2.4.1",
         "clsx": "^2.1.1",
         "openai": "^4.100.0",
         "radix-ui": "^1.4.1",
@@ -447,6 +448,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.32.1", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.32.1", "@typescript-eslint/types": "8.32.1", "@typescript-eslint/typescript-estree": "8.32.1" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-DsSFNIgLSrc89gpq1LJB7Hm1YpuhK086DRDJSNrewcGvYloWW1vZLHBTIvarKZDcAORIy/uWNx8Gad+4oMpkSA=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.32.1", "", { "dependencies": { "@typescript-eslint/types": "8.32.1", "eslint-visitor-keys": "^4.2.0" } }, "sha512-ar0tjQfObzhSaW3C3QNmTc5ofj0hDoNQ5XWrCy6zDyabdr0TWhCkClp+rywGNj/odAFBVzzJrK4tEq5M4Hmu4w=="],
+
+    "@uidotdev/usehooks": ["@uidotdev/usehooks@2.4.1", "", { "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.4.1", "", { "dependencies": { "@babel/core": "^7.26.10", "@babel/plugin-transform-react-jsx-self": "^7.25.9", "@babel/plugin-transform-react-jsx-source": "^7.25.9", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0" } }, "sha512-IpEm5ZmeXAP/osiBXVVP5KjFMzbWOonMs0NaQQl+xYnUAcq4oHUBsF2+p4MgKWG4YMmFYJU8A6sxRPuowllm6w=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/themes": "^3.2.1",
     "@tailwindcss/vite": "^4.1.7",
     "@tanstack/react-query": "^5.76.1",
+    "@uidotdev/usehooks": "^2.4.1",
     "clsx": "^2.1.1",
     "openai": "^4.100.0",
     "radix-ui": "^1.4.1",

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,9 @@
-import { MagnifyingGlassIcon, Pencil2Icon } from "@radix-ui/react-icons";
+import {
+  MagnifyingGlassIcon,
+  MoonIcon,
+  Pencil2Icon,
+  SunIcon,
+} from "@radix-ui/react-icons";
 import {
   Flex,
   IconButton,
@@ -9,6 +14,8 @@ import {
 } from "@radix-ui/themes";
 import { Link as RouterLink } from "react-router";
 import ChatButton from "./ChatButton";
+import { useContext } from "react";
+import { CustomThemeContext } from "../context";
 
 function Sidebar({
   chats,
@@ -17,6 +24,8 @@ function Sidebar({
   chats?: { id: string; title: string }[];
   chatId?: string;
 }) {
+  const { theme, setTheme } = useContext(CustomThemeContext);
+
   return (
     <Flex
       direction="column"
@@ -57,6 +66,21 @@ function Sidebar({
           ))}
         </Flex>
       </ScrollArea>
+
+      <Flex>
+        <IconButton
+          variant="ghost"
+          m="2"
+          onClick={() =>
+            setTheme((t) => ({
+              ...t,
+              appearance: t.appearance === "dark" ? "light" : "dark",
+            }))
+          }
+        >
+          {theme.appearance === "dark" ? <MoonIcon /> : <SunIcon />}
+        </IconButton>
+      </Flex>
     </Flex>
   );
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -18,7 +18,7 @@ import {
 import { Link as RouterLink } from "react-router";
 import ChatButton from "./ChatButton";
 import { useContext } from "react";
-import { accentColors, CustomThemeContext } from "../context";
+import { accentColors, CustomThemeContext, EnvContext } from "../context";
 
 function Sidebar({
   chats,
@@ -27,6 +27,7 @@ function Sidebar({
   chats?: { id: string; title: string }[];
   chatId?: string;
 }) {
+  const env = useContext(EnvContext);
   const { theme, setTheme } = useContext(CustomThemeContext);
 
   return (
@@ -82,27 +83,29 @@ function Sidebar({
         >
           {theme.appearance === "dark" ? <MoonIcon /> : <SunIcon />}
         </IconButton>
-        <Popover.Root>
-          <Popover.Trigger>
-            <IconButton variant="ghost">
-              <ColorWheelIcon />
-            </IconButton>
-          </Popover.Trigger>
-          <Popover.Content className="max-w-2xs!">
-            <Box>
-              {accentColors.map((color) => (
-                <IconButton
-                  key={`color-${color}`}
-                  color={color}
-                  className="m-0.5!"
-                  onClick={() =>
-                    setTheme((t) => ({ ...t, accentColor: color }))
-                  }
-                ></IconButton>
-              ))}
-            </Box>
-          </Popover.Content>
-        </Popover.Root>
+        {!env.DISABLE_USER_SET_THEME_ACCENT_COLOR && (
+          <Popover.Root>
+            <Popover.Trigger>
+              <IconButton variant="ghost">
+                <ColorWheelIcon />
+              </IconButton>
+            </Popover.Trigger>
+            <Popover.Content className="max-w-2xs!">
+              <Box>
+                {accentColors.map((color) => (
+                  <IconButton
+                    key={`color-${color}`}
+                    color={color}
+                    className="m-0.5!"
+                    onClick={() =>
+                      setTheme((t) => ({ ...t, accentColor: color }))
+                    }
+                  ></IconButton>
+                ))}
+              </Box>
+            </Popover.Content>
+          </Popover.Root>
+        )}
       </Flex>
     </Flex>
   );

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,12 +1,15 @@
 import {
+  ColorWheelIcon,
   MagnifyingGlassIcon,
   MoonIcon,
   Pencil2Icon,
   SunIcon,
 } from "@radix-ui/react-icons";
 import {
+  Box,
   Flex,
   IconButton,
+  Popover,
   ScrollArea,
   Separator,
   TextField,
@@ -15,7 +18,7 @@ import {
 import { Link as RouterLink } from "react-router";
 import ChatButton from "./ChatButton";
 import { useContext } from "react";
-import { CustomThemeContext } from "../context";
+import { accentColors, CustomThemeContext } from "../context";
 
 function Sidebar({
   chats,
@@ -67,10 +70,9 @@ function Sidebar({
         </Flex>
       </ScrollArea>
 
-      <Flex>
+      <Flex m="2" gap="4">
         <IconButton
           variant="ghost"
-          m="2"
           onClick={() =>
             setTheme((t) => ({
               ...t,
@@ -80,6 +82,27 @@ function Sidebar({
         >
           {theme.appearance === "dark" ? <MoonIcon /> : <SunIcon />}
         </IconButton>
+        <Popover.Root>
+          <Popover.Trigger>
+            <IconButton variant="ghost">
+              <ColorWheelIcon />
+            </IconButton>
+          </Popover.Trigger>
+          <Popover.Content className="max-w-2xs!">
+            <Box>
+              {accentColors.map((color) => (
+                <IconButton
+                  key={`color-${color}`}
+                  color={color}
+                  className="m-0.5!"
+                  onClick={() =>
+                    setTheme((t) => ({ ...t, accentColor: color }))
+                  }
+                ></IconButton>
+              ))}
+            </Box>
+          </Popover.Content>
+        </Popover.Root>
       </Flex>
     </Flex>
   );

--- a/frontend/src/components/Spinner.tsx
+++ b/frontend/src/components/Spinner.tsx
@@ -1,7 +1,6 @@
 import { clsx } from "clsx";
 
 type SpinnerProps = {
-  size?: number;
   className?: string;
   fullPage?: boolean;
 };
@@ -15,7 +14,7 @@ export default function Spinner({ className, fullPage = true }: SpinnerProps) {
         className,
       )}
     >
-      <div className="animate-spin rounded-full border-4 border-white/20 border-t-white size-12" />
+      <div className="animate-spin rounded-full border-4 border-(--accent-9)/20 border-t-(--accent-9) size-12" />
     </div>
   );
 }

--- a/frontend/src/context/AppProvider.tsx
+++ b/frontend/src/context/AppProvider.tsx
@@ -20,7 +20,9 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
     })();
   }, [env.CHAT_MODELS_FILTER_REGEX, openai.models]);
 
-  if (!models) return (<Spinner/>)
+  if (!models) return <Spinner className="bg-(--accent-2)" />;
 
-  return <AppContext.Provider value={{ models }}>{children}</AppContext.Provider>;
+  return (
+    <AppContext.Provider value={{ models }}>{children}</AppContext.Provider>
+  );
 }

--- a/frontend/src/context/CustomThemeContext.ts
+++ b/frontend/src/context/CustomThemeContext.ts
@@ -1,33 +1,7 @@
 import { createContext } from "react";
 
-export const accentColors = [
-  "gray",
-  "gold",
-  "bronze",
-  "brown",
-  "yellow",
-  "amber",
-  "orange",
-  "tomato",
-  "red",
-  "ruby",
-  "crimson",
-  "pink",
-  "plum",
-  "purple",
-  "violet",
-  "iris",
-  "indigo",
-  "blue",
-  "cyan",
-  "teal",
-  "jade",
-  "green",
-  "grass",
-  "lime",
-  "mint",
-  "sky",
-] as const;
+// prettier-ignore
+export const accentColors = ['gray', 'gold', 'bronze', 'brown', 'yellow', 'amber', 'orange', 'tomato', 'red', 'ruby', 'crimson', 'pink', 'plum', 'purple', 'violet', 'iris', 'indigo', 'blue', 'cyan', 'teal', 'jade', 'green', 'grass', 'lime', 'mint', 'sky'] as const;
 
 type AccentColor = (typeof accentColors)[number];
 

--- a/frontend/src/context/CustomThemeContext.ts
+++ b/frontend/src/context/CustomThemeContext.ts
@@ -1,0 +1,12 @@
+import type { ThemeOwnProps } from "@radix-ui/themes/components/theme.props";
+import { createContext } from "react";
+
+export type CustomTheme = {
+  accentColor: ThemeOwnProps["accentColor"];
+  appearance: "light" | "dark";
+};
+
+export const CustomThemeContext = createContext<{
+  theme: CustomTheme;
+  setTheme: React.Dispatch<React.SetStateAction<CustomTheme>>;
+}>(null!);

--- a/frontend/src/context/CustomThemeContext.ts
+++ b/frontend/src/context/CustomThemeContext.ts
@@ -1,8 +1,38 @@
-import type { ThemeOwnProps } from "@radix-ui/themes/components/theme.props";
 import { createContext } from "react";
 
+export const accentColors = [
+  "gray",
+  "gold",
+  "bronze",
+  "brown",
+  "yellow",
+  "amber",
+  "orange",
+  "tomato",
+  "red",
+  "ruby",
+  "crimson",
+  "pink",
+  "plum",
+  "purple",
+  "violet",
+  "iris",
+  "indigo",
+  "blue",
+  "cyan",
+  "teal",
+  "jade",
+  "green",
+  "grass",
+  "lime",
+  "mint",
+  "sky",
+] as const;
+
+type AccentColor = (typeof accentColors)[number];
+
 export type CustomTheme = {
-  accentColor: ThemeOwnProps["accentColor"];
+  accentColor: AccentColor;
   appearance: "light" | "dark";
 };
 

--- a/frontend/src/context/CustomThemeProvider.tsx
+++ b/frontend/src/context/CustomThemeProvider.tsx
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { CustomThemeContext, type CustomTheme } from "./CustomThemeContext";
 import { Theme } from "@radix-ui/themes";
 import { EnvContext } from "./EnvContext";
@@ -9,12 +9,18 @@ export function CustomThemeProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const { THEME_ACCENT_COLOR, THEME_APPEARANCE } = useContext(EnvContext);
+  const env = useContext(EnvContext);
   const defaultTheme: CustomTheme = {
-    accentColor: THEME_ACCENT_COLOR as any,
-    appearance: THEME_APPEARANCE as any,
+    accentColor: env.THEME_ACCENT_COLOR as any,
+    appearance: env.THEME_APPEARANCE as any,
   };
   const [theme, setTheme] = useLocalStorage("theme", defaultTheme);
+
+  useEffect(() => {
+    if (env.DISABLE_USER_SET_THEME_ACCENT_COLOR) {
+      setTheme((t) => ({ ...t, accentColor: defaultTheme.accentColor }));
+    }
+  }, []);
 
   return (
     <CustomThemeContext.Provider value={{ theme, setTheme }}>

--- a/frontend/src/context/CustomThemeProvider.tsx
+++ b/frontend/src/context/CustomThemeProvider.tsx
@@ -1,7 +1,8 @@
-import { useContext, useState } from "react";
+import { useContext } from "react";
 import { CustomThemeContext, type CustomTheme } from "./CustomThemeContext";
 import { Theme } from "@radix-ui/themes";
 import { EnvContext } from "./EnvContext";
+import { useLocalStorage } from "@uidotdev/usehooks";
 
 export function CustomThemeProvider({
   children,
@@ -9,11 +10,11 @@ export function CustomThemeProvider({
   children: React.ReactNode;
 }) {
   const { THEME_ACCENT_COLOR, THEME_APPEARANCE } = useContext(EnvContext);
-
-  const [theme, setTheme] = useState<CustomTheme>({
+  const defaultTheme: CustomTheme = {
     accentColor: THEME_ACCENT_COLOR as any,
     appearance: THEME_APPEARANCE as any,
-  });
+  };
+  const [theme, setTheme] = useLocalStorage("theme", defaultTheme);
 
   return (
     <CustomThemeContext.Provider value={{ theme, setTheme }}>

--- a/frontend/src/context/CustomThemeProvider.tsx
+++ b/frontend/src/context/CustomThemeProvider.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react";
+import { CustomThemeContext, type CustomTheme } from "./CustomThemeContext";
+import { Theme } from "@radix-ui/themes";
+
+export function CustomThemeProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [theme, setTheme] = useState<CustomTheme>({
+    accentColor: "gray",
+    appearance: "dark",
+  });
+
+  return (
+    <CustomThemeContext.Provider value={{ theme, setTheme }}>
+      <Theme {...theme}>{children}</Theme>
+    </CustomThemeContext.Provider>
+  );
+}

--- a/frontend/src/context/CustomThemeProvider.tsx
+++ b/frontend/src/context/CustomThemeProvider.tsx
@@ -1,15 +1,18 @@
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { CustomThemeContext, type CustomTheme } from "./CustomThemeContext";
 import { Theme } from "@radix-ui/themes";
+import { EnvContext } from "./EnvContext";
 
 export function CustomThemeProvider({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const { THEME_ACCENT_COLOR, THEME_APPEARANCE } = useContext(EnvContext);
+
   const [theme, setTheme] = useState<CustomTheme>({
-    accentColor: "gray",
-    appearance: "dark",
+    accentColor: THEME_ACCENT_COLOR as any,
+    appearance: THEME_APPEARANCE as any,
   });
 
   return (

--- a/frontend/src/context/index.ts
+++ b/frontend/src/context/index.ts
@@ -4,6 +4,9 @@ export * from "./AppProvider";
 export * from "./AuthContext";
 export * from "./AuthProvider";
 
+export * from "./CustomThemeContext";
+export * from "./CustomThemeProvider";
+
 export * from "./EnvContext";
 export * from "./EnvProvider";
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { Theme } from "@radix-ui/themes";
 import "@radix-ui/themes/styles.css";
 import "./index.css";
 import App from "./App.tsx";

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -22,8 +22,8 @@ const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <CustomThemeProvider>
-      <EnvProvider env={env}>
+    <EnvProvider env={env}>
+      <CustomThemeProvider>
         <AuthProvider>
           <QueryClientProvider client={queryClient}>
             <BrowserRouter>
@@ -45,7 +45,7 @@ createRoot(document.getElementById("root")!).render(
             </BrowserRouter>
           </QueryClientProvider>
         </AuthProvider>
-      </EnvProvider>
-    </CustomThemeProvider>
+      </CustomThemeProvider>
+    </EnvProvider>
   </StrictMode>,
 );

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,7 +7,13 @@ import "./index.css";
 import App from "./App.tsx";
 import { client } from "./lib/honoClient.ts";
 import { BrowserRouter, Route, Routes } from "react-router";
-import {EnvProvider, AuthProvider, OpenAiProvider, AppProvider} from './context'
+import {
+  EnvProvider,
+  AuthProvider,
+  OpenAiProvider,
+  AppProvider,
+} from "./context";
+import { CustomThemeProvider } from "./context/CustomThemeProvider.tsx";
 
 // Fetch env eagerly before rendering
 const env = await (await client.env.$get()).json();
@@ -17,30 +23,30 @@ const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <Theme accentColor="gray" appearance="dark">
-        <EnvProvider env={env}>
-          <AuthProvider>
-            <QueryClientProvider client={queryClient}>
-              <BrowserRouter>
-                <Routes>
-                  {["/", "/c/:chatId"].map((path) => (
-                    <Route
-                      key={path}
-                      path={path}
-                      element={
-                        <OpenAiProvider>
-                          <AppProvider>
-                            <App />
-                          </AppProvider>
-                        </OpenAiProvider>
-                      }
-                    />
-                  ))}
-                </Routes>
-              </BrowserRouter>
-            </QueryClientProvider>
-          </AuthProvider>
-        </EnvProvider>
-    </Theme>
-  </StrictMode>
+    <CustomThemeProvider>
+      <EnvProvider env={env}>
+        <AuthProvider>
+          <QueryClientProvider client={queryClient}>
+            <BrowserRouter>
+              <Routes>
+                {["/", "/c/:chatId"].map((path) => (
+                  <Route
+                    key={path}
+                    path={path}
+                    element={
+                      <OpenAiProvider>
+                        <AppProvider>
+                          <App />
+                        </AppProvider>
+                      </OpenAiProvider>
+                    }
+                  />
+                ))}
+              </Routes>
+            </BrowserRouter>
+          </QueryClientProvider>
+        </AuthProvider>
+      </EnvProvider>
+    </CustomThemeProvider>
+  </StrictMode>,
 );


### PR DESCRIPTION
## Summary

- New context: `CustomThemeContext`
- Dark mode toggle
- Theme color picker
- Server-provided default theme
- Option to disable user accent color selection
- Added theme to Spinner element

## Added environment variables

Client/server:

- `THEME_ACCENT_COLOR`: An accent color from https://www.radix-ui.com/themes/docs/theme/color
- `THEME_APPEARANCE`: Either "dark" or "light"
- `DISABLE_USER_SET_THEME_ACCENT_COLOR`: Disable user-set accent colors

## Added packages

- `@uidotdev/usehooks`: Provides convenient hook: [useLocalStorage](https://usehooks.com/uselocalstorage)