### PR TITLE
Simple refresh tokens using JWT

### DIFF
--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -24,6 +24,9 @@ type Env = {
     DISABLE_AUTH: boolean;
     CHAT_MODELS_FILTER_REGEX: string;
     TITLE_GENERATION_PROMPT: string;
+    THEME_ACCENT_COLOR: string;
+    THEME_APPEARANCE: string;
+    DISABLE_USER_SET_THEME_ACCENT_COLOR: boolean;
   };
 };
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { jwt, sign } from "hono/jwt";
+import { jwt, sign, verify } from "hono/jwt";
 import { zValidator } from "@hono/zod-validator";
 import { z } from "zod";
 import { cors } from "hono/cors";
@@ -8,6 +8,30 @@ import getDb from "./db";
 import { createMiddleware } from "hono/factory";
 import { proxy } from "hono/proxy";
 import error from "./error";
+import { getSignedCookie, setSignedCookie } from "hono/cookie";
+
+type SessionJwt = {
+  personId: string;
+  exp: number;
+};
+
+type RefreshJwt = {
+  id: string;
+  personId: string;
+  exp: number;
+};
+
+function dateToUnix(date: Date) {
+  return Math.floor(date.getTime() / 1000);
+}
+
+function unixToDate(seconds: number) {
+  return new Date(seconds * 1000);
+}
+
+function getExpiry(inSeconds: number) {
+  return dateToUnix(new Date()) + inSeconds;
+}
 
 const db = await getDb();
 
@@ -39,7 +63,13 @@ const api = new Hono()
             await next();
           }
         : async (c, next) => {
-            c.set("personId", c.get("jwtPayload").id);
+            const { personId, exp } = c.get("jwtPayload") as SessionJwt;
+
+            if (new Date(exp * 1000) < new Date()) {
+              return error(c, 401);
+            }
+
+            c.set("personId", personId);
             await next();
           },
     ),
@@ -215,7 +245,7 @@ const api = new Hono()
   );
 
 const app = new Hono()
-  .use(cors())
+  .use(cors({ origin: "http://localhost:5173", credentials: true }))
   .route("/api", api)
   .get("/env", (c) => c.json(env.client))
   .post(
@@ -231,17 +261,91 @@ const app = new Hono()
         .executeTakeFirst();
 
       if (person) {
-        const payload = {
-          id: person.id,
-          exp: Math.floor(Date.now() / 1000) + 60 * 5, // Token expires in 5 minutes
+        const payload: SessionJwt = {
+          personId: person.id,
+          exp: getExpiry(env.server.JWT_SESSION_EXP_SEC),
         };
         const token = await sign(payload, env.server.JWT_SECRET);
-        return c.json({ token }, 201);
+
+        const refreshExpiry = getExpiry(env.server.JWT_REFRESH_EXP_SEC);
+        const record = await db
+          .insertInto("refresh_token")
+          .values({
+            person_id: person.id,
+            expires_at: unixToDate(refreshExpiry),
+          })
+          .returningAll()
+          .executeTakeFirst();
+
+        if (record) {
+          const refreshPayload: RefreshJwt = {
+            id: record.id,
+            personId: record.person_id,
+            exp: refreshExpiry,
+          };
+          const refreshToken = await sign(
+            refreshPayload,
+            env.server.JWT_SECRET,
+          );
+
+          await setSignedCookie(
+            c,
+            "fossai_refresh_token",
+            refreshToken,
+            env.server.COOKIE_SECRET,
+            {
+              path: "/",
+              secure: true,
+              httpOnly: true,
+              expires: record.expires_at,
+              sameSite: "strict",
+            },
+          );
+        } else {
+          console.error("Critical Error: Failed to create refresh token!");
+        }
+
+        return c.json({ token }, 200);
       }
 
       return error(c, 401);
     },
   )
+  .post("/refresh", async (c) => {
+    const refreshToken = await getSignedCookie(
+      c,
+      env.server.COOKIE_SECRET,
+      "fossai_refresh_token",
+    );
+
+    if (refreshToken) {
+      const payload = await verify(refreshToken, env.server.JWT_SECRET);
+      const { id, personId, exp } = payload as RefreshJwt;
+      const now = new Date();
+
+      if (new Date(exp * 1000) > now) {
+        const record = await db
+          .selectFrom("refresh_token")
+          .select("id")
+          .where("id", "=", id)
+          .where("person_id", "=", personId)
+          .where("expires_at", ">", now)
+          .executeTakeFirst();
+
+        if (record) {
+          const payload: SessionJwt = {
+            personId,
+            exp: getExpiry(env.server.JWT_SESSION_EXP_SEC),
+          };
+          const token = await sign(payload, env.server.JWT_SECRET);
+
+          return c.json({ token }, 200);
+        }
+      }
+    }
+
+    return error(c, 401);
+  })
   .post(
     "/register",
     zValidator("json", z.object({ email: z.string(), first_name: z.string() })),

--- a/backend/src/init.sql
+++ b/backend/src/init.sql
@@ -26,3 +26,8 @@ create table if not exists message (
     content text not null
 );
 
+create table if not exists refresh_token (
+    id bigint primary key generated always as identity,
+    person_id bigint not null references person(id),
+    expires_at timestamp not null default now()
+);

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -37,8 +37,15 @@ export interface Person {
   id: Generated<Int8>;
 }
 
+export interface RefreshToken {
+  expires_at: Generated<Timestamp>;
+  id: Generated<Int8>;
+  person_id: Int8;
+}
+
 export interface DB {
   chat: Chat;
   message: Message;
   person: Person;
+  refresh_token: RefreshToken;
 }

--- a/frontend/src/api/mutations.ts
+++ b/frontend/src/api/mutations.ts
@@ -10,6 +10,10 @@ export const refresh = async () => {
   return await res.json();
 };
 
+export const logout = async () => {
+  await client.logout.$post();
+};
+
 export const createNewMessage = async (
   headers: Record<string, string>,
   chatId: string,

--- a/frontend/src/api/mutations.ts
+++ b/frontend/src/api/mutations.ts
@@ -1,16 +1,26 @@
 import { client } from "../lib/honoClient";
 
+export const refresh = async () => {
+  const res = await client.refresh.$post();
+
+  if (!res.ok) {
+    throw new Error("Auth using refresh token failed");
+  }
+
+  return await res.json();
+};
+
 export const createNewMessage = async (
   headers: Record<string, string>,
   chatId: string,
-  content: string
+  content: string,
 ) => {
   const res = await client.api.chat[":id"].message.$post(
     {
       param: { id: chatId },
       json: { content, role: "user" },
     },
-    { headers }
+    { headers },
   );
   const { id } = await res.json();
   return id;
@@ -18,31 +28,31 @@ export const createNewMessage = async (
 
 export const createNewChat = async (
   headers: Record<string, string>,
-  content: string
+  content: string,
 ) => {
   const res = await client.api.chat.$post(
     { json: { title: "New Chat" } },
-    { headers }
+    { headers },
   );
   const { id } = await res.json();
   await createNewMessage(headers, id, content);
   return id;
 };
 
-export const deleteChat = async (headers: Record<string, string>, chatId: string) => {
-  await client.api.chat[":id"].$delete(
-    { param: { id: chatId } },
-    { headers },
-  );
+export const deleteChat = async (
+  headers: Record<string, string>,
+  chatId: string,
+) => {
+  await client.api.chat[":id"].$delete({ param: { id: chatId } }, { headers });
 };
 
 export const updateChatTitle = async (
   headers: Record<string, string>,
   chatId: string,
-  title: string
+  title: string,
 ) => {
   await client.api.chat[":id"].$put(
     { param: { id: chatId }, json: { title } },
-    { headers }
+    { headers },
   );
 };

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   Pencil2Icon,
   SunIcon,
   HamburgerMenuIcon,
+  ExitIcon,
 } from "@radix-ui/react-icons";
 import {
   Box,
@@ -22,6 +23,8 @@ import { useContext, useState } from "react";
 import { accentColors, CustomThemeContext, EnvContext } from "../context";
 import Fuse from "fuse.js";
 import clsx from "clsx";
+import { useMutation } from "@tanstack/react-query";
+import { logout } from "../api/mutations";
 
 const collapsedWidthClass = "w-7.5";
 const transitionClass = "transition-all duration-200 ease-in-out";
@@ -37,6 +40,13 @@ function Sidebar({
   const { theme, setTheme } = useContext(CustomThemeContext);
   const [collapsed, setCollapsed] = useState(true);
   const [search, setSearch] = useState("");
+
+  const logoutMutation = useMutation({
+    mutationFn: logout,
+    onSuccess: () => {
+      window.location.reload();
+    },
+  });
 
   const fuse = new Fuse(chats, { keys: ["title"] });
   chats = search ? fuse.search(search).map(({ item }) => item) : chats;
@@ -110,7 +120,7 @@ function Sidebar({
         mx={collapsed ? "0" : "2"}
         my="2"
         gap="3"
-        direction={collapsed ? "column-reverse" : "row"}
+        direction={collapsed ? "column" : "row"}
         className={clsx(transitionClass, collapsed && collapsedWidthClass)}
       >
         <IconButton
@@ -124,6 +134,7 @@ function Sidebar({
         >
           {theme.appearance === "dark" ? <MoonIcon /> : <SunIcon />}
         </IconButton>
+
         {!env.DISABLE_USER_SET_THEME_ACCENT_COLOR && (
           <Popover.Root>
             <Popover.Trigger>
@@ -147,6 +158,12 @@ function Sidebar({
             </Popover.Content>
           </Popover.Root>
         )}
+
+        {!collapsed && <div className="grow" />}
+
+        <IconButton variant="ghost" onClick={() => logoutMutation.mutate()}>
+          <ExitIcon />
+        </IconButton>
       </Flex>
     </Flex>
   );

--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -1,10 +1,30 @@
-import {useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import Login from "../Login";
 import { EnvContext, AuthContext } from ".";
+import { useMutation } from "@tanstack/react-query";
+import { refresh } from "../api/mutations";
+import { Spinner } from "@radix-ui/themes";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const env = useContext(EnvContext);
   const [token, setToken] = useState<string>(null!);
+
+  const { mutate: tryRefresh, isPending } = useMutation({
+    mutationFn: refresh,
+    onSuccess(data) {
+      setToken(data?.token);
+    },
+  });
+
+  useEffect(() => {
+    if (!env.DISABLE_AUTH) {
+      tryRefresh();
+    }
+  }, [env.DISABLE_AUTH, tryRefresh]);
+
+  if (!env.DISABLE_AUTH && isPending) {
+    return <Spinner />;
+  }
 
   if (!env.DISABLE_AUTH && !token) {
     return <Login setToken={setToken} />;

--- a/frontend/src/lib/honoClient.ts
+++ b/frontend/src/lib/honoClient.ts
@@ -1,4 +1,8 @@
 import { hc } from "hono/client";
 import type { AppType } from "@fossai/backend";
 
-export const client = hc<AppType>("http://localhost:3000");
+export const client = hc<AppType>("http://localhost:3000", {
+  init: {
+    credentials: "include",
+  },
+});

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -24,8 +24,8 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <EnvProvider env={env}>
       <CustomThemeProvider>
-        <AuthProvider>
-          <QueryClientProvider client={queryClient}>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>
             <BrowserRouter>
               <Routes>
                 {["/", "/c/:chatId"].map((path) => (
@@ -43,8 +43,8 @@ createRoot(document.getElementById("root")!).render(
                 ))}
               </Routes>
             </BrowserRouter>
-          </QueryClientProvider>
-        </AuthProvider>
+          </AuthProvider>
+        </QueryClientProvider>
       </CustomThemeProvider>
     </EnvProvider>
   </StrictMode>,


### PR DESCRIPTION
closes #1 

### New endpoints

- POST /refresh - reads cookie & logs in user
- POST /logout - deletes cookie & refresh token from DB

### Differences between #21

- simpler refresh_token schema (no `revoked` field, just deletes from DB instead)
- uses JWTs instead of UUIDs so that the server doesn't need to store any sensitive data
- uses signed cookies so that cookies cannot be altered on the client side