### PR TITLE
declarative env vars with strong types

### DIFF
--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -63,6 +63,7 @@ const privateDef: PrivateDef = {
     description: "Base URL of OpenAI API endpoint",
   },
   EMAIL_VALIDATION_REGEX: {
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/email#basic_validation
     value:
       /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/,
     parser: (v) => new RegExp(v),


### PR DESCRIPTION
This aims to declare all of our program's inputs (environment variables) in an easy-to-parse JSON schema for future codegen use cases (generating documentation, Nix options, Docker templates, etc.). This maintains the same interface that the rest of the codebase has been using, but required some TypeScript magic to get working. However, the `privateDef` and `publicDef` schemas are very easy to parse as JSON, and also helps us organize our environment variables.